### PR TITLE
Remove puppetlabs-apt as hard dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The vaz module requires the following puppet module:
 
 - [puppetlabs-apt](https://forge.puppet.com/puppetlabs/apt): version 2.0 or newer (only Debian-based distributions).
 
+puppetlabs-apt is soft dependencies. If you are installing on Debian systems, you will need to configure appropriate versions of this module.
+
 ## Usage
 
 ### Configuring vaz

--- a/metadata.json
+++ b/metadata.json
@@ -22,10 +22,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 3.0.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppetlabs-apt is soft dependency as it's not required under all circumstances by this module.